### PR TITLE
Typo fix ~s~

### DIFF
--- a/blog/_posts/2019-09-20-google-font-tailwind.md
+++ b/blog/_posts/2019-09-20-google-font-tailwind.md
@@ -13,7 +13,7 @@ First, select your font and then add the package to your project via the [typefa
 In my case, I am using [Roboto](https://fonts.google.com/specimen/Roboto) for [How I VSCode](https://howivscode.com).
 
 ```bash
-yarn add typefaces-roboto
+yarn add typeface-roboto
 ```
 
 Next, require the package:


### PR DESCRIPTION
Yarn package is at `typeface-roboto` not `typefaces-roboto`
https://yarnpkg.com/package/typeface-roboto

PS: The blog post is great. Thanks 👍